### PR TITLE
Associate transaction with a given account (and remove offset transaction logic).

### DIFF
--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -1,0 +1,192 @@
+import React, { KeyboardEventHandler } from 'react';
+import CreatableSelect from 'react-select/creatable';
+import { Popover, PopoverTrigger, PopoverContent } from "@nextui-org/popover";
+import {
+    TinyField,
+    TinyButton,
+    SelectContainer,
+    StyledSelect,
+    HelpIcon,
+    HelpTooltip
+} from '../styles/styledComponents';
+
+interface SettingsProps {
+    accessTokenInState: string;
+    setAccessToken: (token: string) => void;
+    setAuthenticated: (authenticated: boolean) => void;
+    showSettings: (show: boolean) => void;
+    showQuickButtons: boolean;
+    setShowQuickButtons: (show: boolean) => void;
+    recentCategories: any[];
+    setRecentCategories: (categories: any[]) => void;
+    recentAssets: any[];
+    setRecentAssets: (assets: any[]) => void;
+    recentCount: number;
+    setRecentCount: (count: number) => void;
+    tags: readonly { label: string; value: string }[];
+    setTags: (tags: readonly { label: string; value: string }[]) => void;
+    inputValue: string;
+    setInputValue: (value: string) => void;
+    handleKeyDown: KeyboardEventHandler<HTMLInputElement>;
+    handleBlur: () => void;
+    addAccessTokenFromHTMLElement: () => void;
+    accessRef: React.RefObject<HTMLInputElement>;
+}
+
+const Settings: React.FC<SettingsProps> = ({
+    accessTokenInState,
+    setAccessToken,
+    setAuthenticated,
+    showSettings,
+    showQuickButtons,
+    setShowQuickButtons,
+    recentCategories,
+    setRecentCategories,
+    recentAssets,
+    setRecentAssets,
+    recentCount,
+    setRecentCount,
+    tags,
+    setTags,
+    inputValue,
+    setInputValue,
+    handleKeyDown,
+    handleBlur,
+    addAccessTokenFromHTMLElement,
+    accessRef
+}) => {
+    const handleRecentCountChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = parseInt(e.target.value, 10);
+        setRecentCount(value);
+    };
+
+    return (
+        <div style={{ width: '100%', margin: '20px 0' }}>
+            {accessTokenInState === null || accessTokenInState.length === 0 ? (
+                <div>
+                    <h3>Welcome!</h3>
+                    <p>This app lets you quickly add manual transactions to LunchMoney on the go.</p>
+                    <p>To get started, add your access token (only stored locally on your device.)</p>
+                    <TinyField
+                        placeholder='LunchMoney Access Token'
+                        type='text'
+                        ref={accessRef}
+                    />
+                    <TinyButton onClick={addAccessTokenFromHTMLElement}>
+                        Add
+                    </TinyButton>
+                </div>
+            ) : (
+                <div>
+                    <h3>Settings:</h3>
+                    <div>
+                        <TinyButton
+                            onClick={() => {
+                                localStorage.removeItem('access_token');
+                                setAccessToken('');
+                                setAuthenticated(false);
+                            }}
+                        >
+                            Delete Access Token (...{accessTokenInState.slice(-6)})
+                        </TinyButton>
+                    </div>
+                    <div>
+                        <p></p><TinyButton onClick={() => {
+                            setShowQuickButtons(!showQuickButtons);
+                            showSettings(false);
+                        }}>
+                            {showQuickButtons ? 'Hide Quick Buttons' : 'Show Quick Buttons'}
+                        </TinyButton>
+                    </div>
+                    {recentCategories.length !== 0 && (
+                        <div>
+                            <p></p><TinyButton
+                                onClick={() => {
+                                    localStorage.removeItem('recentCategories');
+                                    setRecentCategories([]);
+                                    showSettings(false);
+                                }}
+                            >
+                                Clear Recent Categories
+                            </TinyButton>
+                        </div>
+                    )}
+                    {recentAssets.length !== 0 && (
+                        <div>
+                            <p></p><TinyButton
+                                onClick={() => {
+                                    localStorage.removeItem('recentAssets');
+                                    setRecentAssets([]);
+                                    showSettings(false);
+                                }}
+                            >
+                                Clear Recent Assets
+                            </TinyButton>
+                        </div>
+                    )}
+                    <div>
+                        <p></p><label htmlFor="recentCount">Recent categories to show:</label>
+                        <SelectContainer>
+                            <StyledSelect
+                                id="recentCount"
+                                value={recentCount}
+                                onChange={handleRecentCountChange}
+                            >
+                                {Array.from({ length: 10 }, (_, i) => i + 1).map((num) => (
+                                    <option key={num} value={num}>
+                                        {num}
+                                    </option>
+                                ))}
+                            </StyledSelect>
+                        </SelectContainer>
+                    </div>
+                    <div>
+                        <p></p><label htmlFor="tags">Tag all transactions as:</label>
+                        <Popover placement="top-start">
+                            <PopoverTrigger>
+                                <HelpIcon>?</HelpIcon>
+                            </PopoverTrigger>
+                            <PopoverContent>
+                                <HelpTooltip>
+                                    Tag(s) that will be added to all transactions (e.g., &quot;cash&quot;,
+                                    &quot; manual-cash&quot;, &quot;milk-money&quot;, etc.) to make it easier
+                                    to track transactions entered from this tool.
+                                    <p></p>Leave empty to disable.
+                                </HelpTooltip>
+                            </PopoverContent>
+                        </Popover>
+                        <CreatableSelect
+                            id="tags"
+                            components={{ DropdownIndicator: null }}
+                            inputValue={inputValue}
+                            isClearable
+                            isMulti
+                            menuIsOpen={false}
+                            onChange={(newValue) => { setTags(newValue) }}
+                            onInputChange={(newValue: any) => setInputValue(newValue as string)}
+                            onKeyDown={handleKeyDown}
+                            onBlur={handleBlur}
+                            value={tags}
+                            styles={{
+                                control: (provided, state) => ({
+                                    ...provided,
+                                    padding: '6px 6px',
+                                    margin: 'auto',
+                                    color: '#404040',
+                                    fontSize: '20px',
+                                    backgroundColor: '#fff',
+                                    borderRadius: '5px',
+                                    border: '1px solid #404040',
+                                    width: '100%',
+                                }),
+                            }}
+                            placeholder="Type to set tag(s)..."
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default Settings;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@nextui-org/popover": "^2.1.29",
                 "dayjs": "^1.11.12",
-                "next": "^14.2.14",
+                "next": "^14.2.21",
                 "next-plausible": "^3.12.1",
                 "next-pwa": "^5.6.0",
                 "react": "^18.3.1",
@@ -1992,10 +1992,9 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.15.tgz",
-            "integrity": "sha512-S1qaj25Wru2dUpcIZMjxeMVSwkt8BK4dmWHHiBuRstcIyOsMapqT4A4jSB6onvqeygkSSmOkyny9VVx8JIGamQ==",
-            "license": "MIT"
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.21.tgz",
+            "integrity": "sha512-lXcwcJd5oR01tggjWJ6SrNNYFGuOOMB9c251wUNkjCpkoXOPkDeF/15c3mnVlBqrW4JJXb2kVxDFhC4GduJt2A=="
         },
         "node_modules/@next/eslint-plugin-next": {
             "version": "14.2.5",
@@ -2008,13 +2007,12 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.15.tgz",
-            "integrity": "sha512-Rvh7KU9hOUBnZ9TJ28n2Oa7dD9cvDBKua9IKx7cfQQ0GoYUwg9ig31O2oMwH3wm+pE3IkAQ67ZobPfEgurPZIA==",
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.21.tgz",
+            "integrity": "sha512-HwEjcKsXtvszXz5q5Z7wCtrHeTTDSTgAbocz45PHMUjU3fBYInfvhR+ZhavDRUYLonm53aHZbB09QtJVJj8T7g==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -2024,13 +2022,12 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
-            "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.21.tgz",
+            "integrity": "sha512-TSAA2ROgNzm4FhKbTbyJOBrsREOMVdDIltZ6aZiKvCi/v0UwFmwigBGeqXDA97TFMpR3LNNpw52CbVelkoQBxA==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -2040,13 +2037,12 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
-            "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.21.tgz",
+            "integrity": "sha512-0Dqjn0pEUz3JG+AImpnMMW/m8hRtl1GQCNbO66V1yp6RswSTiKmnHf3pTX6xMdJYSemf3O4Q9ykiL0jymu0TuA==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2056,13 +2052,12 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
-            "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.21.tgz",
+            "integrity": "sha512-Ggfw5qnMXldscVntwnjfaQs5GbBbjioV4B4loP+bjqNEb42fzZlAaK+ldL0jm2CTJga9LynBMhekNfV8W4+HBw==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2072,13 +2067,12 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
-            "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.21.tgz",
+            "integrity": "sha512-uokj0lubN1WoSa5KKdThVPRffGyiWlm/vCc/cMkWOQHw69Qt0X1o3b2PyLLx8ANqlefILZh1EdfLRz9gVpG6tg==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2088,13 +2082,12 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
-            "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.21.tgz",
+            "integrity": "sha512-iAEBPzWNbciah4+0yI4s7Pce6BIoxTQ0AGCkxn/UBuzJFkYyJt71MadYQkjPqCQCJAFQ26sYh7MOKdU+VQFgPg==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -2104,13 +2097,12 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
-            "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.21.tgz",
+            "integrity": "sha512-plykgB3vL2hB4Z32W3ktsfqyuyGAPxqwiyrAi2Mr8LlEUhNn9VgkiAl5hODSBpzIfWweX3er1f5uNpGDygfQVQ==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -2120,13 +2112,12 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
-            "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.21.tgz",
+            "integrity": "sha512-w5bacz4Vxqrh06BjWgua3Yf7EMDb8iMcVhNrNx8KnJXt8t+Uu0Zg4JHLDL/T7DkTCEEfKXO/Er1fcfWxn2xfPA==",
             "cpu": [
                 "ia32"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -2136,13 +2127,12 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
-            "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.21.tgz",
+            "integrity": "sha512-sT6+llIkzpsexGYZq8cjjthRyRGe5cJVhqh12FmlbxHqna6zsDDK8UNaV7g41T6atFHCJUPeLb3uyAwrBwy0NA==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -4249,10 +4239,9 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "license": "MIT",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -7344,16 +7333,15 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -7377,12 +7365,11 @@
             "peer": true
         },
         "node_modules/next": {
-            "version": "14.2.15",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.2.15.tgz",
-            "integrity": "sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==",
-            "license": "MIT",
+            "version": "14.2.21",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.2.21.tgz",
+            "integrity": "sha512-rZmLwucLHr3/zfDMYbJXbw0ZeoBpirxkXuvsJbk7UPorvPYZhP7vq7aHbKnU7dQNCYIimRrbB2pp3xmf+wsYUg==",
             "dependencies": {
-                "@next/env": "14.2.15",
+                "@next/env": "14.2.21",
                 "@swc/helpers": "0.5.5",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",
@@ -7397,15 +7384,15 @@
                 "node": ">=18.17.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "14.2.15",
-                "@next/swc-darwin-x64": "14.2.15",
-                "@next/swc-linux-arm64-gnu": "14.2.15",
-                "@next/swc-linux-arm64-musl": "14.2.15",
-                "@next/swc-linux-x64-gnu": "14.2.15",
-                "@next/swc-linux-x64-musl": "14.2.15",
-                "@next/swc-win32-arm64-msvc": "14.2.15",
-                "@next/swc-win32-ia32-msvc": "14.2.15",
-                "@next/swc-win32-x64-msvc": "14.2.15"
+                "@next/swc-darwin-arm64": "14.2.21",
+                "@next/swc-darwin-x64": "14.2.21",
+                "@next/swc-linux-arm64-gnu": "14.2.21",
+                "@next/swc-linux-arm64-musl": "14.2.21",
+                "@next/swc-linux-x64-gnu": "14.2.21",
+                "@next/swc-linux-x64-musl": "14.2.21",
+                "@next/swc-win32-arm64-msvc": "14.2.21",
+                "@next/swc-win32-ia32-msvc": "14.2.21",
+                "@next/swc-win32-x64-msvc": "14.2.21"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "@nextui-org/popover": "^2.1.29",
         "dayjs": "^1.11.12",
-        "next": "^14.2.14",
+        "next": "^14.2.21",
         "next-plausible": "^3.12.1",
         "next-pwa": "^5.6.0",
         "react": "^18.3.1",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -363,6 +363,20 @@ const Home: React.FC = () => {
         count: number
     }[]>([]);
     const [recentAssetCount, setRecentAssetCount] = useState<number>(3);
+    const [transactionCleared, setTransactionCleared] = useState<boolean>(false);
+
+    useEffect(() => {
+        // Retrieve the transactionCleared state from localStorage
+        const storedTransactionCleared = localStorage.getItem('transactionCleared');
+        if (storedTransactionCleared) {
+            setTransactionCleared(JSON.parse(storedTransactionCleared));
+        }
+    }, []);
+
+    useEffect(() => {
+        // Save the transactionCleared state to localStorage whenever it changes
+        localStorage.setItem('transactionCleared', JSON.stringify(transactionCleared));
+    }, [transactionCleared]);
 
     const categoryOptions = cats?.filter(cat => !cat.is_group)
                                  .filter(cat => !cat.archived)
@@ -637,6 +651,10 @@ const Home: React.FC = () => {
         }
     };
 
+    const handleTransactionClearedChange = (checked: boolean) => {
+        setTransactionCleared(checked);
+    };
+
     const insertTransaction = async () => {
         setLoading(true);
         let timeoutId: ReturnType<typeof setTimeout>;
@@ -666,6 +684,7 @@ const Home: React.FC = () => {
             payee: payee,
             notes: notes,
             tags: tagValues,
+            status: transactionCleared ? "cleared" : "uncleared",
         }];
 
         var now = dayjs();
@@ -942,6 +961,42 @@ const Home: React.FC = () => {
                             </>
                         )}
 
+                        {assets !== null && assets.length > 0 && (
+                            <>
+                                <CategoryHolder>
+                                    {recentAssets.map((assetone, i) => (
+                                        <CategorySelector
+                                            key={i}
+                                            value={assetone.asset.id}
+                                            selected={
+                                                selectedAsset !== null &&
+                                                selectedAsset.id === assetone.asset.id
+                                            }
+                                            $dimmed={
+                                                selectedAsset === null || (selectedAsset !== null &&
+                                                selectedAsset.id !== assetone.asset.id)
+                                            }
+                                            onClick={() => {
+                                                setChosenAsset(assetone.asset);
+                                                updateRecentAssets(assetone.asset);
+                                            }}
+                                        >
+                                            {assetone.asset.name}
+                                        </CategorySelector>
+                                    ))}
+                                </CategoryHolder>
+
+                                <Select
+                                    value={selectedAsset}
+                                    onChange={handleAssetChange}
+                                    options={assetOptions}
+                                    isSearchable={false}
+                                    placeholder={recentAssets.length === 0 ? 'Select an asset...' : 'More assets...'}
+                                    styles={menuStyles}
+                                />
+                            </>
+                        )}
+
                         {cats !== null && (
                             <>
                                 <CategoryHolder>
@@ -979,42 +1034,6 @@ const Home: React.FC = () => {
                             </>
                         )}
 
-                        {assets !== null && assets.length > 0 && (
-                            <>
-                                <CategoryHolder>
-                                    {recentAssets.map((assetone, i) => (
-                                        <CategorySelector
-                                            key={i}
-                                            value={assetone.asset.id}
-                                            selected={
-                                                selectedAsset !== null &&
-                                                selectedAsset.id === assetone.asset.id
-                                            }
-                                            $dimmed={
-                                                selectedAsset === null || (selectedAsset !== null &&
-                                                selectedAsset.id !== assetone.asset.id)
-                                            }
-                                            onClick={() => {
-                                                setChosenAsset(assetone.asset);
-                                                updateRecentAssets(assetone.asset);
-                                            }}
-                                        >
-                                            {assetone.asset.name}
-                                        </CategorySelector>
-                                    ))}
-                                </CategoryHolder>
-
-                                <Select
-                                    value={selectedAsset}
-                                    onChange={handleAssetChange}
-                                    options={assetOptions}
-                                    isSearchable={false}
-                                    placeholder={recentAssets.length === 0 ? 'Select an asset...' : 'More assets...'}
-                                    styles={menuStyles}
-                                />
-                            </>
-                        )}
-
                         <p></p>
                         <TinyField
                             id='notes'
@@ -1028,6 +1047,14 @@ const Home: React.FC = () => {
                             type="text"
                         />
                         <p></p>
+                        <div style={{ display: 'inline-flex', alignItems: 'center' }}>
+                            <label htmlFor="transactionCleared" style={{ marginRight: '10px' }}>Transaction Cleared: </label>
+                            <Switch
+                                onChange={handleTransactionClearedChange}
+                                checked={transactionCleared}
+                                id="transactionCleared"
+                            />
+                        </div>
                         <Button onClick={() => insertTransaction()}>
                             Add Transaction
                         </Button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -782,6 +782,19 @@ const Home: React.FC = () => {
                                         </TinyButton>
                                     </div>
                                 )}
+                                {recentAssets.length !== 0 && (
+                                    <div>
+                                        <p></p><TinyButton
+                                            onClick={() => {
+                                                localStorage.removeItem('recentAssets');
+                                                setRecentAssets([]);
+                                                showSettings(false);
+                                            }}
+                                        >
+                                            Clear Recent Assets
+                                        </TinyButton>
+                                    </div>
+                                )}
                                 <div>
                                     <p></p><label htmlFor="recentCount">Recent categories to show:</label>
                                     <SelectContainer>
@@ -829,22 +842,24 @@ const Home: React.FC = () => {
                                         placeholder= "Type to set tag(s)..."
                                     />
                                 </div>
-                                <div>
-                                    <p></p><label htmlFor="recentAssetCount">Recent assets to show:</label>
-                                    <SelectContainer>
-                                        <StyledSelect
-                                            id="recentAssetCount"
-                                            value={recentAssetCount}
-                                            onChange={handleRecentAssetCountChange}
-                                        >
-                                            {Array.from({ length: 10 }, (_, i) => i + 1).map((num) => (
-                                                <option key={num} value={num}>
-                                                    {num}
-                                                </option>
-                                            ))}
-                                        </StyledSelect>
-                                    </SelectContainer>
-                                </div>
+                                {assets && assets.length > 0 && (
+                                    <div>
+                                        <p></p><label htmlFor="recentAssetCount">Recent assets to show:</label>
+                                        <SelectContainer>
+                                            <StyledSelect
+                                                id="recentAssetCount"
+                                                value={recentAssetCount}
+                                                onChange={handleRecentAssetCountChange}
+                                            >
+                                                {Array.from({ length: 10 }, (_, i) => i + 1).map((num) => (
+                                                    <option key={num} value={num}>
+                                                        {num}
+                                                    </option>
+                                                ))}
+                                            </StyledSelect>
+                                        </SelectContainer>
+                                    </div>
+                                )}
                             </div>
                         )}
                     </div>
@@ -964,7 +979,7 @@ const Home: React.FC = () => {
                             </>
                         )}
 
-                        {assets !== null && (
+                        {assets !== null && assets.length > 0 && (
                             <>
                                 <CategoryHolder>
                                     {recentAssets.map((assetone, i) => (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -404,6 +404,9 @@ const Home: React.FC = () => {
             setSelectedAsset(selectedOption.value);
             setChosenAsset(selectedOption.value);
             updateRecentAssets(selectedOption.value);
+            if (amountRef.current) {
+                amountRef.current.focus();
+            }
         }
     };
 
@@ -418,6 +421,9 @@ const Home: React.FC = () => {
 
     const setChosenAsset = (newAsset: LunchMoneyAsset) => {
         setSelectedAsset(newAsset);
+        if (amountRef.current) {
+            amountRef.current.focus();
+        }
     };
 
     const downloadCats = async (at: string) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -412,11 +412,6 @@ const Home: React.FC = () => {
 
     const setChosenCategory = (newCategory: LunchMoneyCategory) => {
         setCategory(newCategory);
-
-        // Set focus to the notes input after setting the category.
-        if (notesRef.current) {
-            notesRef.current.focus();
-        }
     };
 
     const setChosenAsset = (newAsset: LunchMoneyAsset) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -286,7 +286,7 @@ interface LunchMoneyAsset {
     id: number;
     type_name: string;
     subtype_name: string | null;
-    name: string;
+    display_name: string;
     balance: string;
     balance_as_of: string;
     currency: string;
@@ -389,7 +389,7 @@ const Home: React.FC = () => {
 
     const assetOptions: Option<LunchMoneyAsset>[] = assets?.map((asset) => ({
         value: asset,
-        label: asset.name,
+        label: asset.display_name,
     })) || [];
 
     const handleCategoryChange = (selectedOption: any) => {
@@ -885,7 +885,7 @@ const Home: React.FC = () => {
                                                 updateRecentAssets(assetone);
                                             }}
                                         >
-                                            {assetone.name}
+                                            {assetone.display_name}
                                         </CategorySelector>
                                     ))}
                                 </CategoryHolder>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -56,7 +56,7 @@ const HeaderContainer = styled.div`
     }
 `;
 
-const CategoryHolder = styled.div`
+const ItemHolder = styled.div`
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -64,21 +64,21 @@ const CategoryHolder = styled.div`
     margin: 20px 0;
 `;
 
-interface CategoryI {
+interface ItemI {
     selected: boolean;
     $dimmed: boolean;
     value?: number;
 }
-const CategorySelector = styled.div<CategoryI>`
+const ItemSelector = styled.div<ItemI>`
     display: inline-block;
     padding: 12px 12px;
     margin: 5px;
     font-size: 17px;
     cursor: pointer;
-    background-color: ${(props: CategoryI) =>
+    background-color: ${(props: ItemI) =>
         props.selected ? '#006bb3' : '#e6e6e6'};
     border-radius: 8px;
-    color: ${(props: CategoryI) => (props.$dimmed ? 'black' : 'white')};
+    color: ${(props: ItemI) => (props.$dimmed ? 'black' : 'white')};
 `;
 
 const InputWrapper = styled.div`
@@ -855,9 +855,9 @@ const Home: React.FC = () => {
 
                         {assets !== null && assets.length > 0 && (
                             <>
-                                <CategoryHolder>
+                                <ItemHolder>
                                     {assets.map((assetone, i) => (
-                                        <CategorySelector
+                                        <ItemSelector
                                             key={i}
                                             value={assetone.id}
                                             selected={
@@ -874,9 +874,9 @@ const Home: React.FC = () => {
                                             }}
                                         >
                                             {assetone.display_name}
-                                        </CategorySelector>
+                                        </ItemSelector>
                                     ))}
-                                </CategoryHolder>
+                                </ItemHolder>
                             </>
                         )}
 
@@ -954,9 +954,9 @@ const Home: React.FC = () => {
 
                         {cats !== null && (
                             <>
-                                <CategoryHolder>
+                                <ItemHolder>
                                     {recentCategories.map((catone, i) => (
-                                        <CategorySelector
+                                        <ItemSelector
                                             key={i}
                                             value={catone.category.id}
                                             selected={
@@ -974,9 +974,9 @@ const Home: React.FC = () => {
                                             }}
                                         >
                                             {catone.category.name}
-                                        </CategorySelector>
+                                        </ItemSelector>
                                     ))}
-                                </CategoryHolder>
+                                </ItemHolder>
 
                                 <Select
                                     value={selectedCategory}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,272 +1,35 @@
 import Head from 'next/head';
 import React, { createRef, useEffect, useState, useRef, KeyboardEventHandler } from 'react';
 import dayjs from 'dayjs';
-import styled from 'styled-components';
 import Select from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import Switch from "react-switch";
 import {Popover, PopoverTrigger, PopoverContent} from "@nextui-org/popover";
-
-
-const MoneyAdder = styled.div`
-    display: flex;
-    flex-direction: row;
-    flex-flow: row wrap;
-    margin: 10px 0 30px 0;
-    justify-content: space-between;
-    gap: 15px;
-
-    > button {
-        display: inline-flex;
-        margin: 0 5px 0 0;
-        cursor: pointer;
-        padding: 13px 20px;
-        color: #000;
-        background-color: #fff;
-        border: 1px solid #404040;
-    }
-`;
-
-const Gear = styled.div`
-    font-size: 22px;
-    cursor: pointer;
-    justify-self: flex-end;
-`;
-
-const CategoryHeaderGroup = styled.div`
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-
-    h3 {
-        margin: 0;
-        display: inline;
-    }
-`;
-
-const HeaderContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-
-    h1 {
-        margin: 5px 20px;
-        font-size: 30px;
-    }
-`;
-
-const ItemHolder = styled.div`
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    margin: 20px 0;
-`;
-
-interface ItemI {
-    selected: boolean;
-    $dimmed: boolean;
-    value?: number;
-}
-const ItemSelector = styled.div<ItemI>`
-    display: inline-block;
-    padding: 12px 12px;
-    margin: 5px;
-    font-size: 17px;
-    cursor: pointer;
-    background-color: ${(props: ItemI) =>
-        props.selected ? '#006bb3' : '#e6e6e6'};
-    border-radius: 8px;
-    color: ${(props: ItemI) => (props.$dimmed ? 'black' : 'white')};
-`;
-
-const InputWrapper = styled.div`
-    width: 100%;
-    border: 1px solid #404040;
-    font-size: 22px;
-    border-radius: 5px;
-    padding: 5px 10px;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    height: 100px;
-`;
-
-const TheSingleStepper = styled.div`
-    width: 200px;
-    display: flex;
-    flex-direction: column;
-`;
-
-const ValueChange = styled.div`
-    width: 110px;
-    height: 25px;
-    color: #404040;
-    text-align: center;
-    border-radius: 8px;
-    font-size: 17px;
-    padding: 3px 3px;
-    align-items: center;
-    cursor: pointer;
-`;
-
-const AppContainer = styled.div`
-    min-height: 100vh;
-    padding: 0 0.5rem;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-`;
-
-const MainContainer = styled.div`
-    padding: 10px;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
-    width: 100%;
-    max-width: 400px;
-
-    label {
-        text-align: left;
-        margin: 10px 0;
-        font-weight: 600;
-        width: 100%;
-        font-size: 16px;
-    }
-`;
-
-const Button = styled.button`
-    width: 100%;
-    background-color: #006bb3;
-    color: #fff;
-    padding: 10px 30px;
-    margin: 20px auto;
-    border: none;
-    border-radius: 10px;
-    font-size: 20px;
-    font-weight: 700;
-`;
-
-const TinyField = styled.input`
-    padding: 12px 12px;
-    margin: auto;
-    display: inline;
-    color: #404040;
-    font-size: 20px;
-    border-radius: 5px;
-    border: 1px solid #404040;
-    width: 100%;
-`;
-
-const TinyButton = styled.button`
-    width: 100%;
-    background-color: #006bb3;
-    color: #fff;
-    padding: 10px 30px;
-    border: none;
-    border-radius: 10px;
-    font-size: 18px;
-    font-weight: 700;
-`;
-
-const NumberInput = styled.input`
-    font-size: 40px;
-    border: none;
-    width: 50%;
-    margin: 0 0 0 10px;
-    display: inline-block;
-
-    &:focus {
-        outline: none;
-    }
-`;
-
-const DollarSign = styled.span`
-    font-size: 22px;
-    margin: 0 0 0 30px;
-`;
-
-const SuccessHolder = styled.div`
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: center;
-
-    p {
-        font-size: 17px;
-    }
-`;
-
-const WarningHolder = styled.div`
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: center;
-    font-size: 17px;
-    color: red;
-`;
-
-const SelectContainer = styled.div`
-    display: flex;
-    align-items: center;
-    width: 100%;
-    margin: 10px 0;
-`;
-
-const StyledSelect = styled.select`
-    width: 100%;
-    padding: 8px;
-    font-size: 20px;
-    border: 1px solid #404040;
-    border-radius: 5px;
-    color: '#404040',
-    background-color: '#fff',
-`;
-
-const Footer = styled.div`
-    width: 100%;
-    border-top: 1px solid #eaeaea;
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    padding: 10px 0;
-    align-items: center;
-
-    p {
-        font-size: 12px;
-    }
-`;
-
-const HelpIcon = styled.span`
-    display: inline-block;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    border: 1px solid #ccc;
-    text-align: center;
-    line-height: 20px;
-    cursor: pointer;
-    margin-left: 5px; /* Adjust as needed */
-
-    &:hover {
-        background-color: #eee;
-    }
-`;
-
-const HelpTooltip = styled.div`
-    font-size: 16px;
-    background-color: #99cbff;
-    border: 1px solid #ccc;
-    padding: 8px;
-    border-radius: 4px;
-    max-width: 300px;
-`;
+import {
+    MoneyAdder,
+    Gear,
+    CategoryHeaderGroup,
+    HeaderContainer,
+    ItemHolder,
+    ItemSelector,
+    InputWrapper,
+    TheSingleStepper,
+    ValueChange,
+    AppContainer,
+    MainContainer,
+    Button,
+    TinyField,
+    TinyButton,
+    NumberInput,
+    DollarSign,
+    SuccessHolder,
+    WarningHolder,
+    SelectContainer,
+    StyledSelect,
+    Footer,
+    HelpIcon,
+    HelpTooltip
+} from '../styles/styledComponents';
 
 interface LunchMoneyCategory {
     id: number;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -304,7 +304,7 @@ interface Option<T> {
     readonly value: T;
 }
 
-const createOption = (label: string) => ({
+const createOption = (label: string): Option<string> => ({
     label,
     value: label,
 });
@@ -351,7 +351,7 @@ const Home: React.FC = () => {
     const recentCountRef = createRef<HTMLInputElement>();
 
     const [inputValue, setInputValue] = useState('');
-    const [tags, setTags] = useState<readonly Option[]>([]);
+    const [tags, setTags] = useState<readonly Option<string>[]>([]);
     const [showTooltip, setShowTooltip] = useState(false);
 
     const [selectedCategory, setSelectedCategory] = useState<any>(null);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,6 +30,7 @@ import {
     HelpIcon,
     HelpTooltip
 } from '../styles/styledComponents';
+import { StylesConfig } from 'react-select';
 
 interface LunchMoneyCategory {
     id: number;
@@ -73,7 +74,7 @@ const createOption = (label: string): Option<string> => ({
 });
 
 const Home: React.FC = () => {
-    const menuStyles = {
+    const menuStyles: StylesConfig<any, false> = {
         control: (provided, state) => ({
             ...provided,
             padding: '6px 6px',
@@ -155,11 +156,13 @@ const Home: React.FC = () => {
         label: asset.display_name,
     })) || [];
 
-    const handleCategoryChange = (selectedOption: any) => {
-        setSelectedCategory(selectedOption);
-        setChosenCategory(selectedOption.value);
-        updateRecentCategories(selectedOption.value);
-        setNoCategoryWarning(false);
+    const handleCategoryChange = (selectedOption: Option<LunchMoneyCategory> | null) => {
+        if (selectedOption) {
+            setSelectedCategory(selectedOption);
+            setChosenCategory(selectedOption.value);
+            updateRecentCategories(selectedOption.value);
+            setNoCategoryWarning(false);
+        }
     };
 
     const handleAssetChange = (selectedOption: Option<LunchMoneyAsset> | null) => {
@@ -223,7 +226,7 @@ const Home: React.FC = () => {
         setError('');
     };
 
-    const handleKeyDown: KeyboardEventHandler = (event) => {
+    const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
         if (!inputValue) return;
 
         switch (event.key) {
@@ -387,7 +390,7 @@ const Home: React.FC = () => {
         setRecentCount(value);
     };
 
-    const handleNotesKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const handleNotesKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
         if (e.key === 'Enter') {  // Check if Enter key is pressed
             e.preventDefault();  // Prevent default form submission behavior (important!)
             insertTransaction(); // Call your transaction function

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -299,9 +299,9 @@ const components = {
     DropdownIndicator: null,
 };
 
-interface Option {
+interface Option<T> {
     readonly label: string;
-    readonly value: string;
+    readonly value: T;
 }
 
 const createOption = (label: string) => ({
@@ -388,7 +388,7 @@ const Home: React.FC = () => {
                                      label: cat.name,
                                  })) || [];
 
-    const assetOptions = assets?.map((asset) => ({
+    const assetOptions: Option<LunchMoneyAsset>[] = assets?.map((asset) => ({
         value: asset,
         label: asset.name,
     })) || [];
@@ -400,10 +400,12 @@ const Home: React.FC = () => {
         setNoCategoryWarning(false);
     };
 
-    const handleAssetChange = (selectedOption: any) => {
-        setSelectedAsset(selectedOption.value);
-        setChosenAsset(selectedOption.value);
-        updateRecentAssets(selectedOption.value);
+    const handleAssetChange = (selectedOption: Option<LunchMoneyAsset> | null) => {
+        if (selectedOption) {
+            setSelectedAsset(selectedOption.value);
+            setChosenAsset(selectedOption.value);
+            updateRecentAssets(selectedOption.value);
+        }
     };
 
     const setChosenCategory = (newCategory: LunchMoneyCategory) => {
@@ -987,7 +989,7 @@ const Home: React.FC = () => {
                                 </CategoryHolder>
 
                                 <Select
-                                    value={selectedAsset}
+                                    value={selectedAsset ? { value: selectedAsset, label: selectedAsset.name } : null}
                                     onChange={handleAssetChange}
                                     options={assetOptions}
                                     isSearchable={false}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -700,6 +700,8 @@ const Home: React.FC = () => {
                 setChosenCategory(null);
                 setSelectedCategory(null);
                 setCategory(null);
+                setChosenAsset(null);
+                setSelectedAsset(null);
                 timeoutId = setTimeout(() => {
                     setSuccess(false);
                 }, 3000);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -357,7 +357,7 @@ const Home: React.FC = () => {
     const [selectedCategory, setSelectedCategory] = useState<any>(null);
 
     const [assets, setAssets] = useState<Array<LunchMoneyAsset> | null>(null);
-    const [selectedAsset, setSelectedAsset] = useState<LunchMoneyAsset | null>(null);
+    const [chosenAsset, setChosenAsset] = useState<LunchMoneyAsset | null>(null);
     const [recentAssets, setRecentAssets] = useState<{
         asset: LunchMoneyAsset;
         count: number
@@ -401,7 +401,6 @@ const Home: React.FC = () => {
 
     const handleAssetChange = (selectedOption: Option<LunchMoneyAsset> | null) => {
         if (selectedOption) {
-            setSelectedAsset(selectedOption.value);
             setChosenAsset(selectedOption.value);
             updateRecentAssets(selectedOption.value);
             if (amountRef.current) {
@@ -412,13 +411,6 @@ const Home: React.FC = () => {
 
     const setChosenCategory = (newCategory: LunchMoneyCategory) => {
         setCategory(newCategory);
-    };
-
-    const setChosenAsset = (newAsset: LunchMoneyAsset) => {
-        setSelectedAsset(newAsset);
-        if (amountRef.current) {
-            amountRef.current.focus();
-        }
     };
 
     const downloadCats = async (at: string) => {
@@ -667,7 +659,7 @@ const Home: React.FC = () => {
         const transactionsToInsert = [{
             amount: negative ? `-${amount}` : amount,
             category_id: category.id,
-            asset_id: selectedAsset?.id,
+            asset_id: chosenAsset?.id,
             date: date,
             payee: payee,
             notes: notes,
@@ -701,7 +693,6 @@ const Home: React.FC = () => {
                 setSelectedCategory(null);
                 setCategory(null);
                 setChosenAsset(null);
-                setSelectedAsset(null);
                 timeoutId = setTimeout(() => {
                     setSuccess(false);
                 }, 3000);
@@ -870,12 +861,12 @@ const Home: React.FC = () => {
                                             key={i}
                                             value={assetone.id}
                                             selected={
-                                                selectedAsset !== null &&
-                                                selectedAsset.id === assetone.id
+                                                chosenAsset !== null &&
+                                                chosenAsset.id === assetone.id
                                             }
                                             $dimmed={
-                                                selectedAsset === null || (selectedAsset !== null &&
-                                                selectedAsset.id !== assetone.id)
+                                                chosenAsset === null || (chosenAsset !== null &&
+                                                chosenAsset.id !== assetone.id)
                                             }
                                             onClick={() => {
                                                 setChosenAsset(assetone);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,12 @@
-import Head from 'next/head';
 import React, { createRef, useEffect, useState, useRef, KeyboardEventHandler } from 'react';
+import Head from 'next/head';
 import dayjs from 'dayjs';
 import Select from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import Switch from "react-switch";
-import {Popover, PopoverTrigger, PopoverContent} from "@nextui-org/popover";
+import { Popover, PopoverTrigger, PopoverContent } from "@nextui-org/popover";
+import { StylesConfig } from 'react-select';
+
 import {
     MoneyAdder,
     Gear,
@@ -30,7 +32,6 @@ import {
     HelpIcon,
     HelpTooltip
 } from '../styles/styledComponents';
-import { StylesConfig } from 'react-select';
 
 interface LunchMoneyCategory {
     id: number;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,6 +33,8 @@ import {
     HelpTooltip
 } from '../styles/styledComponents';
 
+import Settings from '../components/Settings';
+
 interface LunchMoneyCategory {
     id: number;
     name: string;
@@ -494,124 +496,28 @@ const Home: React.FC = () => {
                 </HeaderContainer>
 
                 {(!authenticated || settings) && (
-                    <div style={{ width: '100%', margin: '20px 0' }}>
-
-                        {accessTokenInState === null || accessTokenInState.length === 0 ? (
-                            <div>
-                                <h3>Welcome!</h3>
-                                <p>This app lets you quickly add manual transactions to LunchMoney on the go.</p>
-                                <p>To get started, add your access token (only stored locally on your device.)</p>
-                                <TinyField
-                                    placeholder='LunchMoney Access Token'
-                                    type='text'
-                                    ref={accessRef}
-                                />
-                                <TinyButton
-                                    onClick={() =>
-                                        addAccessTokenFromHTMLElement()
-                                    }
-                                >
-                                    Add
-                                </TinyButton>
-                            </div>
-                        ) : (
-                            <div>
-                                <h3>Settings:</h3>
-                                <div>
-                                    <TinyButton
-                                        onClick={() => {
-                                            localStorage.removeItem('access_token');
-                                            setAccessToken('');
-                                            setAuthenticated(false);
-                                        }}
-                                    >
-                                        Delete Access Token (...{accessTokenInState.slice(-6)})
-                                    </TinyButton>
-                                </div>
-                                <div>  {/* New toggle for quick buttons */}
-                                    <p></p><TinyButton onClick={() => {
-                                        setShowQuickButtons(!showQuickButtons);
-                                        showSettings(false);
-                                    }}>
-                                        {showQuickButtons ? 'Hide Quick Buttons' : 'Show Quick Buttons'}
-                                    </TinyButton>
-                                </div>
-                                {recentCategories.length !== 0 && (
-                                    <div>
-                                        <p></p><TinyButton
-                                            onClick={() => {
-                                                localStorage.removeItem('recentCategories');
-                                                setRecentCategories([]);
-                                                showSettings(false);
-                                            }}
-                                        >
-                                            Clear Recent Categories
-                                        </TinyButton>
-                                    </div>
-                                )}
-                                {recentAssets.length !== 0 && (
-                                    <div>
-                                        <p></p><TinyButton
-                                            onClick={() => {
-                                                localStorage.removeItem('recentAssets');
-                                                setRecentAssets([]);
-                                                showSettings(false);
-                                            }}
-                                        >
-                                            Clear Recent Assets
-                                        </TinyButton>
-                                    </div>
-                                )}
-                                <div>
-                                    <p></p><label htmlFor="recentCount">Recent categories to show:</label>
-                                    <SelectContainer>
-                                        <StyledSelect
-                                            id="recentCount"
-                                            value={recentCount}
-                                            onChange={handleRecentCountChange}
-                                        >
-                                            {Array.from({ length: 10 }, (_, i) => i + 1).map((num) => (
-                                                <option key={num} value={num}>
-                                                    {num}
-                                                </option>
-                                            ))}
-                                        </StyledSelect>
-                                    </SelectContainer>
-                                </div>
-                                <div>
-                                    <p></p><label htmlFor="tags">Tag all transactions as:</label>
-                                    <Popover placement="top-start">
-                                        <PopoverTrigger>
-                                            <HelpIcon>?</HelpIcon>
-                                        </PopoverTrigger>
-                                        <PopoverContent>
-                                            <HelpTooltip>
-                                                Tag(s) that will be added to all transactions (e.g., &quot;cash&quot;,
-                                                &quot; manual-cash&quot;, &quot;milk-money&quot;, etc.) to make it easier
-                                                to track transactions entered from this tool.
-                                                <p></p>Leave empty to disable.
-                                            </HelpTooltip>
-                                        </PopoverContent>
-                                    </Popover>
-                                    <CreatableSelect
-                                        id="tags"
-                                        components={components}
-                                        inputValue={inputValue}
-                                        isClearable
-                                        isMulti
-                                        menuIsOpen={false}
-                                        onChange={(newValue) => {setTags(newValue)}}
-                                        onInputChange={(newValue: any) => setInputValue(newValue as string)}
-                                        onKeyDown={handleKeyDown}
-                                        onBlur={handleBlur}
-                                        value={tags}
-                                        styles={menuStyles}
-                                        placeholder= "Type to set tag(s)..."
-                                    />
-                                </div>
-                            </div>
-                        )}
-                    </div>
+                    <Settings
+                        accessTokenInState={accessTokenInState}
+                        setAccessToken={setAccessToken}
+                        setAuthenticated={setAuthenticated}
+                        showSettings={showSettings}
+                        showQuickButtons={showQuickButtons}
+                        setShowQuickButtons={setShowQuickButtons}
+                        recentCategories={recentCategories}
+                        setRecentCategories={setRecentCategories}
+                        recentAssets={recentAssets}
+                        setRecentAssets={setRecentAssets}
+                        recentCount={recentCount}
+                        setRecentCount={setRecentCount}
+                        tags={tags}
+                        setTags={setTags}
+                        inputValue={inputValue}
+                        setInputValue={setInputValue}
+                        handleKeyDown={handleKeyDown}
+                        handleBlur={handleBlur}
+                        addAccessTokenFromHTMLElement={addAccessTokenFromHTMLElement}
+                        accessRef={accessRef}
+                    />
                 )}
 
                 {authenticated && !settings && (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -362,7 +362,6 @@ const Home: React.FC = () => {
         asset: LunchMoneyAsset;
         count: number
     }[]>([]);
-    const [recentAssetCount, setRecentAssetCount] = useState<number>(3);
     const [transactionCleared, setTransactionCleared] = useState<boolean>(false);
 
     useEffect(() => {
@@ -537,10 +536,6 @@ const Home: React.FC = () => {
             setRecentAssets(JSON.parse(storedRecentAssets));
         }
 
-        const storedRecentAssetCount = localStorage.getItem('recentAssetCount');
-        if (storedRecentAssetCount) {
-            setRecentAssetCount(parseInt(storedRecentAssetCount, 10));
-        }
     }, []);
 
     useEffect(() => {
@@ -592,10 +587,6 @@ const Home: React.FC = () => {
         localStorage.setItem('recentAssets', JSON.stringify(recentAssets));
     }, [recentAssets]);
 
-    useEffect(() => {
-        localStorage.setItem('recentAssetCount', recentAssetCount.toString());
-    }, [recentAssetCount]);
-
     const updateRecentCategories = (newCategory: LunchMoneyCategory) => {
         let updatedRecent = [...recentCategories];
         const existingCategoryIndex = updatedRecent.findIndex(item => item.category.id === newCategory.id);
@@ -628,7 +619,6 @@ const Home: React.FC = () => {
         }
 
         updatedRecent.sort((a, b) => b.count - a.count);
-        updatedRecent = updatedRecent.slice(0, recentAssetCount);
 
         if (JSON.stringify(updatedRecent) !== JSON.stringify(recentAssets)) {
             setRecentAssets(updatedRecent);
@@ -639,11 +629,6 @@ const Home: React.FC = () => {
     const handleRecentCountChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const value = parseInt(e.target.value, 10);
         setRecentCount(value);
-    };
-
-    const handleRecentAssetCountChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-        const value = parseInt(e.target.value, 10);
-        setRecentAssetCount(value);
     };
 
     const handleNotesKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -863,24 +848,6 @@ const Home: React.FC = () => {
                                         placeholder= "Type to set tag(s)..."
                                     />
                                 </div>
-                                {assets && assets.length > 0 && (
-                                    <div>
-                                        <p></p><label htmlFor="recentAssetCount">Recent assets to show:</label>
-                                        <SelectContainer>
-                                            <StyledSelect
-                                                id="recentAssetCount"
-                                                value={recentAssetCount}
-                                                onChange={handleRecentAssetCountChange}
-                                            >
-                                                {Array.from({ length: 10 }, (_, i) => i + 1).map((num) => (
-                                                    <option key={num} value={num}>
-                                                        {num}
-                                                    </option>
-                                                ))}
-                                            </StyledSelect>
-                                        </SelectContainer>
-                                    </div>
-                                )}
                             </div>
                         )}
                     </div>
@@ -891,6 +858,34 @@ const Home: React.FC = () => {
                         {error.length > 0 &&
                             accessTokenInState !== null && accessTokenInState.length !== 0 && <p><WarningHolder>{error}</WarningHolder></p>}
                         <p></p>
+
+                        {assets !== null && assets.length > 0 && (
+                            <>
+                                <CategoryHolder>
+                                    {assets.map((assetone, i) => (
+                                        <CategorySelector
+                                            key={i}
+                                            value={assetone.id}
+                                            selected={
+                                                selectedAsset !== null &&
+                                                selectedAsset.id === assetone.id
+                                            }
+                                            $dimmed={
+                                                selectedAsset === null || (selectedAsset !== null &&
+                                                selectedAsset.id !== assetone.id)
+                                            }
+                                            onClick={() => {
+                                                setChosenAsset(assetone);
+                                                updateRecentAssets(assetone);
+                                            }}
+                                        >
+                                            {assetone.name}
+                                        </CategorySelector>
+                                    ))}
+                                </CategoryHolder>
+                            </>
+                        )}
+
                         <InputWrapper>
                             <DollarSign>$</DollarSign>
                             <NumberInput
@@ -960,42 +955,6 @@ const Home: React.FC = () => {
                                     $100
                                 </button>
                             </MoneyAdder>
-                            </>
-                        )}
-
-                        {assets !== null && assets.length > 0 && (
-                            <>
-                                <CategoryHolder>
-                                    {recentAssets.map((assetone, i) => (
-                                        <CategorySelector
-                                            key={i}
-                                            value={assetone.asset.id}
-                                            selected={
-                                                selectedAsset !== null &&
-                                                selectedAsset.id === assetone.asset.id
-                                            }
-                                            $dimmed={
-                                                selectedAsset === null || (selectedAsset !== null &&
-                                                selectedAsset.id !== assetone.asset.id)
-                                            }
-                                            onClick={() => {
-                                                setChosenAsset(assetone.asset);
-                                                updateRecentAssets(assetone.asset);
-                                            }}
-                                        >
-                                            {assetone.asset.name}
-                                        </CategorySelector>
-                                    ))}
-                                </CategoryHolder>
-
-                                <Select
-                                    value={selectedAsset ? { value: selectedAsset, label: selectedAsset.name } : null}
-                                    onChange={handleAssetChange}
-                                    options={assetOptions}
-                                    isSearchable={false}
-                                    placeholder={recentAssets.length === 0 ? 'Select an asset...' : 'More assets...'}
-                                    styles={menuStyles}
-                                />
                             </>
                         )}
 

--- a/styles/styledComponents.ts
+++ b/styles/styledComponents.ts
@@ -1,0 +1,261 @@
+import styled from 'styled-components';
+
+export const MoneyAdder = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-flow: row wrap;
+    margin: 10px 0 30px 0;
+    justify-content: space-between;
+    gap: 15px;
+
+    > button {
+        display: inline-flex;
+        margin: 0 5px 0 0;
+        cursor: pointer;
+        padding: 13px 20px;
+        color: #000;
+        background-color: #fff;
+        border: 1px solid #404040;
+    }
+`;
+
+export const Gear = styled.div`
+    font-size: 22px;
+    cursor: pointer;
+    justify-self: flex-end;
+`;
+
+export const CategoryHeaderGroup = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    h3 {
+        margin: 0;
+        display: inline;
+    }
+`;
+
+export const HeaderContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+
+    h1 {
+        margin: 5px 20px;
+        font-size: 30px;
+    }
+`;
+
+export const ItemHolder = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin: 20px 0;
+`;
+
+interface ItemI {
+    selected: boolean;
+    $dimmed: boolean;
+    value?: number;
+}
+export const ItemSelector = styled.div<ItemI>`
+    display: inline-block;
+    padding: 12px 12px;
+    margin: 5px;
+    font-size: 17px;
+    cursor: pointer;
+    background-color: ${(props: ItemI) =>
+        props.selected ? '#006bb3' : '#e6e6e6'};
+    border-radius: 8px;
+    color: ${(props: ItemI) => (props.$dimmed ? 'black' : 'white')};
+`;
+
+export const InputWrapper = styled.div`
+    width: 100%;
+    border: 1px solid #404040;
+    font-size: 22px;
+    border-radius: 5px;
+    padding: 5px 10px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 100px;
+`;
+
+export const TheSingleStepper = styled.div`
+    width: 200px;
+    display: flex;
+    flex-direction: column;
+`;
+
+export const ValueChange = styled.div`
+    width: 110px;
+    height: 25px;
+    color: #404040;
+    text-align: center;
+    border-radius: 8px;
+    font-size: 17px;
+    padding: 3px 3px;
+    align-items: center;
+    cursor: pointer;
+`;
+
+export const AppContainer = styled.div`
+    min-height: 100vh;
+    padding: 0 0.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+`;
+
+export const MainContainer = styled.div`
+    padding: 10px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    width: 100%;
+    max-width: 400px;
+
+    label {
+        text-align: left;
+        margin: 10px 0;
+        font-weight: 600;
+        width: 100%;
+        font-size: 16px;
+    }
+`;
+
+export const Button = styled.button`
+    width: 100%;
+    background-color: #006bb3;
+    color: #fff;
+    padding: 10px 30px;
+    margin: 20px auto;
+    border: none;
+    border-radius: 10px;
+    font-size: 20px;
+    font-weight: 700;
+`;
+
+export const TinyField = styled.input`
+    padding: 12px 12px;
+    margin: auto;
+    display: inline;
+    color: #404040;
+    font-size: 20px;
+    border-radius: 5px;
+    border: 1px solid #404040;
+    width: 100%;
+`;
+
+export const TinyButton = styled.button`
+    width: 100%;
+    background-color: #006bb3;
+    color: #fff;
+    padding: 10px 30px;
+    border: none;
+    border-radius: 10px;
+    font-size: 18px;
+    font-weight: 700;
+`;
+
+export const NumberInput = styled.input`
+    font-size: 40px;
+    border: none;
+    width: 50%;
+    margin: 0 0 0 10px;
+    display: inline-block;
+
+    &:focus {
+        outline: none;
+    }
+`;
+
+export const DollarSign = styled.span`
+    font-size: 22px;
+    margin: 0 0 0 30px;
+`;
+
+export const SuccessHolder = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+
+    p {
+        font-size: 17px;
+    }
+`;
+
+export const WarningHolder = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    font-size: 17px;
+    color: red;
+`;
+
+export const SelectContainer = styled.div`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    margin: 10px 0;
+`;
+
+export const StyledSelect = styled.select`
+    width: 100%;
+    padding: 8px;
+    font-size: 20px;
+    border: 1px solid #404040;
+    border-radius: 5px;
+    color: '#404040',
+    background-color: '#fff',
+`;
+
+export const Footer = styled.div`
+    width: 100%;
+    border-top: 1px solid #eaeaea;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    padding: 10px 0;
+    align-items: center;
+
+    p {
+        font-size: 12px;
+    }
+`;
+
+export const HelpIcon = styled.span`
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: 1px solid #ccc;
+    text-align: center;
+    line-height: 20px;
+    cursor: pointer;
+    margin-left: 5px; /* Adjust as needed */
+
+    &:hover {
+        background-color: #eee;
+    }
+`;
+
+export const HelpTooltip = styled.div`
+    font-size: 16px;
+    background-color: #99cbff;
+    border: 1px solid #ccc;
+    padding: 8px;
+    border-radius: 4px;
+    max-width: 300px;
+`;


### PR DESCRIPTION
If the user has manually-tracked accounts, it will fetch them and allow users to select an account to associate the transaction with.

As a cleanup, removes all the logic to add offset transactions. Turns out a better practice is to have a manually tracked account (e.g., cash wallet) which is funded with LM transfers (perhaps from ATM withdrawal transactions).